### PR TITLE
docs: use cache action before setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,6 @@ This action should work well with the official Coursier [cache-action](https://g
 ```yml
   steps:
     - uses: actions/checkout@v2
+    - uses: coursier/cache-action@v6
     - uses: laughedelic/coursier-setup@v1
-    - uses: coursier/cache-action@v5
 ```


### PR DESCRIPTION
So JVM and other apps can be restored before the setup action.

[Here is an example PR](https://github.com/2m/yabai-scala/pull/8), where I changed cache-action to run before setup action. Setup action in this case took only 3 seconds and it did not redownload JVM:

```
Install JVM
  /opt/hostedtoolcache/cs/2.0.16/x64/cs java --jvm adopt:14 -version
  openjdk version "14.0.2" 2020-07-14
  OpenJDK Runtime Environment AdoptOpenJDK (build 14.0.2+12)
  OpenJDK 64-Bit Server VM AdoptOpenJDK (build 14.0.2+12, mixed mode, sharing)
  /opt/hostedtoolcache/cs/2.0.16/x64/cs java-home --jvm adopt:14
  /home/runner/.cache/coursier/jvm/adopt@1.14.0-2
```

An [example PR before this change](https://github.com/2m/yabai-scala/pull/7) shows that setup action takes 16 seconds and JVM would be redownloaded every time:

```
Install JVM
  /opt/hostedtoolcache/cs/2.0.16/x64/cs java --jvm adopt:14 -version
  Still downloading:
  AdoptOpenJDK/openjdk14-binaries@jdk-14.0.2%2B12 OpenJDK14U-jdk_x64_linux_hotspot_14.0.2_12.tar.gz (download) (71.54 %, 150784538 / 210764986)
  
  Extracting
    /home/runner/.cache/coursier/v1/https/github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.2%252B12/OpenJDK14U-jdk_x64_linux_hotspot_14.0.2_12.tar.gz
  in
    /home/runner/.cache/coursier/jvm/adopt@1.14.0-2
  Done
  openjdk version "14.0.2" 2020-07-14
  OpenJDK Runtime Environment AdoptOpenJDK (build 14.0.2+12)
  OpenJDK 64-Bit Server VM AdoptOpenJDK (build 14.0.2+12, mixed mode, sharing)
  /opt/hostedtoolcache/cs/2.0.16/x64/cs java-home --jvm adopt:14
  /home/runner/.cache/coursier/jvm/adopt@1.14.0-2
```

Let me know if there was another reason cache action was put after setup. :)